### PR TITLE
feat(deserialization): add ToonDecodeError with line and source attrs

### DIFF
--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -1,6 +1,21 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString};
 
+/// Build a `ToonDecodeError` with `.line` and `.source` attributes set
+/// (either may be `None` when the offending location is unknown).
+fn make_decode_error(
+    py: Python,
+    message: String,
+    line: Option<usize>,
+    source: Option<&str>,
+) -> PyErr {
+    let err = PyErr::new::<crate::ToonDecodeError, _>(message);
+    let value = err.value(py);
+    let _ = value.setattr(pyo3::intern!(py, "line"), line);
+    let _ = value.setattr(pyo3::intern!(py, "source"), source);
+    err
+}
+
 /// Deserialize a TOON format string to a Python object.
 ///
 /// # Arguments
@@ -68,10 +83,12 @@ pub fn check_key_conflict(
             || (existing_is_list && !new_is_list)
             || (!existing_is_list && new_is_list)
         {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                "TOON parse error: Path expansion conflict at key '{}'",
-                key
-            )));
+            return Err(make_decode_error(
+                target.py(),
+                format!("TOON parse error: Path expansion conflict at key '{}'", key),
+                None,
+                None,
+            ));
         }
     }
 
@@ -129,10 +146,12 @@ pub fn deep_merge_path(
                     || (existing_is_list && !new_is_list)
                     || (!existing_is_list && new_is_list)
                 {
-                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                        "TOON parse error: Path expansion conflict at key '{}'",
-                        key
-                    )));
+                    return Err(make_decode_error(
+                        py,
+                        format!("TOON parse error: Path expansion conflict at key '{}'", key),
+                        None,
+                        None,
+                    ));
                 }
             }
         }
@@ -152,10 +171,15 @@ pub fn deep_merge_path(
         } else {
             // Type conflict - existing value is not an object
             if strict {
-                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "TOON parse error: Path expansion conflict at key '{}'",
-                    first_segment
-                )));
+                return Err(make_decode_error(
+                    py,
+                    format!(
+                        "TOON parse error: Path expansion conflict at key '{}'",
+                        first_segment
+                    ),
+                    None,
+                    None,
+                ));
             }
             // In non-strict mode, overwrite with new object (LWW)
             let new_dict = PyDict::new(py);
@@ -204,37 +228,21 @@ impl<'a> Parser<'a> {
         self.err_at(py, self.pos, msg)
     }
 
-    /// Build a `ToonDecodeError` with structured line context from an
-    /// explicit line index.
-    ///
-    /// The returned exception carries:
-    /// - a default message of `"TOON parse error at line N: <msg>"`
-    ///   (or `"TOON parse error: <msg>"` if the line is unknown),
-    ///   accessible via `str(exc)` or `exc.args[0]`. The
-    ///   `"TOON parse error"` prefix is preserved from prior versions
-    ///   for backward compatibility with substring matchers.
-    /// - `.line` — the 1-based line number (`None` if the document is empty);
-    /// - `.source` — the raw source line including indentation
-    ///   (`None` if the document is empty).
+    /// Build a `ToonDecodeError` from an explicit line index, populating
+    /// `.line` (1-based) and `.source` (raw line including indentation).
+    /// Both are `None` for an empty input.
     fn err_at(&self, py: Python, line_idx: usize, msg: impl Into<String>) -> PyErr {
         let (line_num, source) = if self.lines.is_empty() {
             (None, None)
         } else {
             let clamped = line_idx.min(self.lines.len() - 1);
-            (Some(clamped + 1), Some(self.lines[clamped].to_string()))
+            (Some(clamped + 1), Some(self.lines[clamped]))
         };
         let formatted = match line_num {
             Some(n) => format!("TOON parse error at line {}: {}", n, msg.into()),
             None => format!("TOON parse error: {}", msg.into()),
         };
-        let err = PyErr::new::<crate::ToonDecodeError, _>(formatted);
-        // Materialize and decorate with structured attributes. The setattr
-        // calls cannot meaningfully fail (the exception object is a fresh
-        // BaseException instance), so we ignore Result.
-        let value = err.value(py);
-        let _ = value.setattr(pyo3::intern!(py, "line"), line_num);
-        let _ = value.setattr(pyo3::intern!(py, "source"), source);
-        err
+        make_decode_error(py, formatted, line_num, source)
     }
 
     fn detect_indent_size(&mut self) {
@@ -266,7 +274,7 @@ impl<'a> Parser<'a> {
         let indent_part = &line[..indent_len];
 
         if indent_part.contains('\t') {
-            return Err(self.err_here(py,"Tabs are not allowed in indentation"));
+            return Err(self.err_here(py, "Tabs are not allowed in indentation"));
         }
 
         // Use explicit_indent if provided, otherwise use auto-detected indent_size
@@ -277,10 +285,13 @@ impl<'a> Parser<'a> {
         };
 
         if check_indent > 0 && indent_len % check_indent != 0 {
-            return Err(self.err_here(py,format!(
-                "Indentation {} is not a multiple of indent size {}",
-                indent_len, check_indent
-            )));
+            return Err(self.err_here(
+                py,
+                format!(
+                    "Indentation {} is not a multiple of indent size {}",
+                    indent_len, check_indent
+                ),
+            ));
         }
 
         Ok(())
@@ -303,7 +314,7 @@ impl<'a> Parser<'a> {
         }
 
         let first_line = self.lines[self.pos];
-        self.validate_indentation(py,first_line)?;
+        self.validate_indentation(py, first_line)?;
         let first_line_trimmed = first_line.trim();
 
         // Check if it's a root array header - can be [N]: or [N]{fields}:
@@ -326,7 +337,7 @@ impl<'a> Parser<'a> {
     fn parse_root_array(&mut self, py: Python) -> PyResult<Py<PyAny>> {
         let header_idx = self.pos;
         let header = self.lines[self.pos];
-        let (length, delimiter, fields) = self.parse_header(py,header, header_idx)?;
+        let (length, delimiter, fields) = self.parse_header(py, header, header_idx)?;
         self.pos += 1;
 
         if let Some(field_names) = fields {
@@ -346,7 +357,7 @@ impl<'a> Parser<'a> {
                 }
             } else {
                 // Malformed
-                Err(self.err_at(py,header_idx, "Invalid array header"))
+                Err(self.err_at(py, header_idx, "Invalid array header"))
             }
         }
     }
@@ -356,7 +367,7 @@ impl<'a> Parser<'a> {
 
         while self.pos < self.lines.len() {
             let line = self.lines[self.pos];
-            self.validate_indentation(py,line)?;
+            self.validate_indentation(py, line)?;
 
             let line_trimmed = line.trim();
             if line_trimmed.is_empty() {
@@ -441,12 +452,12 @@ impl<'a> Parser<'a> {
                             deep_merge_path(py, &dict, &segments, value, self.strict)?;
                         } else {
                             check_key_conflict(&dict, key_name, value.bind(py), self.strict)?;
-                            let key = self.parse_key(py,key_name)?;
+                            let key = self.parse_key(py, key_name)?;
                             dict.set_item(key, value)?;
                         }
                     } else {
                         let key = if was_quoted {
-                            self.parse_key(py,key_name)?
+                            self.parse_key(py, key_name)?
                         } else {
                             key_name.to_string()
                         };
@@ -458,7 +469,7 @@ impl<'a> Parser<'a> {
 
                 // Parse the key and check if it was quoted
                 let (should_expand, was_quoted) = self.should_expand_key(key_part);
-                let parsed_key = self.parse_key(py,key_part)?;
+                let parsed_key = self.parse_key(py, key_part)?;
                 self.pos += 1;
 
                 if value_part.is_empty() {
@@ -528,7 +539,7 @@ impl<'a> Parser<'a> {
                 }
             } else {
                 // Missing colon error
-                return Err(self.err_here(py,format!("Missing colon in line: {}", line_trimmed)));
+                return Err(self.err_here(py, format!("Missing colon in line: {}", line_trimmed)));
             }
         }
 
@@ -542,7 +553,7 @@ impl<'a> Parser<'a> {
         depth: usize,
     ) -> PyResult<Py<PyAny>> {
         let header_idx = self.pos;
-        let (length, delimiter, fields) = self.parse_header(py,header_line, header_idx)?;
+        let (length, delimiter, fields) = self.parse_header(py, header_line, header_idx)?;
         self.pos += 1;
 
         if let Some(field_names) = fields {
@@ -557,7 +568,7 @@ impl<'a> Parser<'a> {
                     self.parse_expanded_array(py, length, depth + 1, header_idx)
                 }
             } else {
-                Err(self.err_at(py,header_idx, "Invalid array header"))
+                Err(self.err_at(py, header_idx, "Invalid array header"))
             }
         }
     }
@@ -570,19 +581,20 @@ impl<'a> Parser<'a> {
     ) -> PyResult<(usize, char, Option<Vec<String>>)> {
         let trimmed = header.trim();
 
-        let bracket_start = self.find_array_bracket_start(trimmed).ok_or_else(|| {
-            self.err_at(py,header_line_idx, "Invalid array header: missing '['")
-        })?;
+        let bracket_start = self
+            .find_array_bracket_start(trimmed)
+            .ok_or_else(|| self.err_at(py, header_line_idx, "Invalid array header: missing '['"))?;
 
         let bracket_end = trimmed[bracket_start..]
             .find(']')
             .map(|pos| pos + bracket_start)
-            .ok_or_else(|| self.err_at(py,header_line_idx, "Invalid array header: missing ']'"))?;
+            .ok_or_else(|| self.err_at(py, header_line_idx, "Invalid array header: missing ']'"))?;
 
         let bracket_content = &trimmed[bracket_start + 1..bracket_end];
 
         if bracket_content.trim_start().starts_with('#') {
-            return Err(self.err_at(py,
+            return Err(self.err_at(
+                py,
                 header_line_idx,
                 "[#N] headers were removed in v2.0; use [N]",
             ));
@@ -599,7 +611,8 @@ impl<'a> Parser<'a> {
         };
 
         let length = length_str.parse::<usize>().map_err(|_| {
-            self.err_at(py,
+            self.err_at(
+                py,
                 header_line_idx,
                 format!("Invalid array length: {}", length_str),
             )
@@ -610,18 +623,19 @@ impl<'a> Parser<'a> {
             .find_unquoted_char(substring_after_bracket, ':')
             .unwrap_or(substring_after_bracket.len());
         let fields = if let Some(brace_start) = substring_after_bracket[..colon_pos].find('{') {
-            let brace_end_relative = substring_after_bracket[..colon_pos]
-                .find('}')
-                .ok_or_else(|| {
-                    self.err_at(py,header_line_idx, "Invalid field list: missing '}'")
-                })?;
+            let brace_end_relative =
+                substring_after_bracket[..colon_pos]
+                    .find('}')
+                    .ok_or_else(|| {
+                        self.err_at(py, header_line_idx, "Invalid field list: missing '}'")
+                    })?;
 
             let field_content = &substring_after_bracket[brace_start + 1..brace_end_relative];
             let field_parts = self.split_by_delimiter(field_content, delimiter);
             let field_names: Vec<String> = field_parts
                 .iter()
                 .map(|f| {
-                    self.parse_key(py,f.trim())
+                    self.parse_key(py, f.trim())
                         .unwrap_or_else(|_| f.trim().to_string())
                 })
                 .collect();
@@ -649,7 +663,7 @@ impl<'a> Parser<'a> {
             let line_trimmed = line.trim();
 
             if !line_trimmed.is_empty() {
-                self.validate_indentation(py,line)?;
+                self.validate_indentation(py, line)?;
                 let line_depth = self.get_depth(line);
 
                 if line_depth < expected_depth {
@@ -674,7 +688,7 @@ impl<'a> Parser<'a> {
                 }
 
                 if self.strict {
-                    return Err(self.err_here(py,"Blank line inside array"));
+                    return Err(self.err_here(py, "Blank line inside array"));
                 }
                 self.pos += 1;
                 continue;
@@ -687,11 +701,14 @@ impl<'a> Parser<'a> {
             let values = self.split_by_delimiter(line_trimmed, delimiter);
 
             if values.len() != fields.len() {
-                return Err(self.err_here(py,format!(
-                    "Tabular row has {} values but header defines {} fields",
-                    values.len(),
-                    fields.len()
-                )));
+                return Err(self.err_here(
+                    py,
+                    format!(
+                        "Tabular row has {} values but header defines {} fields",
+                        values.len(),
+                        fields.len()
+                    ),
+                ));
             }
 
             let dict = PyDict::new(py);
@@ -709,7 +726,8 @@ impl<'a> Parser<'a> {
 
         let actual_len = list.len();
         if length > 0 && actual_len != length {
-            return Err(self.err_at(py,
+            return Err(self.err_at(
+                py,
                 header_line_idx,
                 format!(
                     "Array declared length {} but found {} elements",
@@ -733,7 +751,8 @@ impl<'a> Parser<'a> {
 
         if values_str.is_empty() {
             if length > 0 {
-                return Err(self.err_at(py,
+                return Err(self.err_at(
+                    py,
                     header_line_idx,
                     format!("Array declared length {} but found 0 elements", length),
                 ));
@@ -744,7 +763,8 @@ impl<'a> Parser<'a> {
         let values = self.split_by_delimiter(values_str, delimiter);
 
         if length > 0 && values.len() != length {
-            return Err(self.err_at(py,
+            return Err(self.err_at(
+                py,
                 header_line_idx,
                 format!(
                     "Array declared length {} but found {} elements",
@@ -776,7 +796,7 @@ impl<'a> Parser<'a> {
             let line_trimmed = line.trim();
 
             if !line_trimmed.is_empty() {
-                self.validate_indentation(py,line)?;
+                self.validate_indentation(py, line)?;
                 let line_depth = self.get_depth(line);
 
                 if line_depth < expected_depth {
@@ -801,7 +821,7 @@ impl<'a> Parser<'a> {
                 }
 
                 if self.strict {
-                    return Err(self.err_here(py,"Blank line inside array"));
+                    return Err(self.err_here(py, "Blank line inside array"));
                 }
                 self.pos += 1;
                 continue;
@@ -831,13 +851,17 @@ impl<'a> Parser<'a> {
                 let header_part = item_str.split("]:").next().unwrap();
                 let header_with_bracket = format!("{}]", header_part);
                 let (inner_len, inner_delim, _) =
-                    self.parse_header(py,&header_with_bracket, item_line_idx)?;
+                    self.parse_header(py, &header_with_bracket, item_line_idx)?;
 
                 let after_colon = item_str.split("]:").nth(1).unwrap_or("").trim();
 
                 if after_colon.is_empty() {
-                    let value =
-                        self.parse_expanded_array(py, inner_len, expected_depth + 1, item_line_idx)?;
+                    let value = self.parse_expanded_array(
+                        py,
+                        inner_len,
+                        expected_depth + 1,
+                        item_line_idx,
+                    )?;
                     list.append(value)?;
                 } else {
                     let value = self.parse_inline_array(
@@ -861,7 +885,8 @@ impl<'a> Parser<'a> {
 
         let actual_len = list.len();
         if length > 0 && actual_len != length {
-            return Err(self.err_at(py,
+            return Err(self.err_at(
+                py,
                 header_line_idx,
                 format!(
                     "Array declared length {} but found {} elements",
@@ -900,10 +925,10 @@ impl<'a> Parser<'a> {
                     } else {
                         key_part.split('[').next().unwrap()
                     };
-                    let key = self.parse_key(py,key_name)?;
+                    let key = self.parse_key(py, key_name)?;
                     dict.set_item(key, value)?;
                 } else {
-                    let key = self.parse_key(py,key_part)?;
+                    let key = self.parse_key(py, key_part)?;
                     self.pos += 1;
 
                     if value_part.is_empty() {
@@ -924,7 +949,7 @@ impl<'a> Parser<'a> {
 
         while self.pos < self.lines.len() {
             let line = self.lines[self.pos];
-            self.validate_indentation(py,line)?;
+            self.validate_indentation(py, line)?;
             let line_depth = self.get_depth(line);
 
             if line_depth <= list_depth {
@@ -958,12 +983,12 @@ impl<'a> Parser<'a> {
                     } else {
                         key_part.split('[').next().unwrap()
                     };
-                    let key = self.parse_key(py,key_name)?;
+                    let key = self.parse_key(py, key_name)?;
                     dict.set_item(key, value)?;
                     continue;
                 }
 
-                let key = self.parse_key(py,key_part)?;
+                let key = self.parse_key(py, key_part)?;
                 self.pos += 1;
 
                 if value_part.is_empty() {
@@ -986,9 +1011,9 @@ impl<'a> Parser<'a> {
 
         if trimmed.starts_with('"') {
             if !trimmed.ends_with('"') || trimmed.len() < 2 {
-                return Err(self.err_here(py,"Unterminated string"));
+                return Err(self.err_here(py, "Unterminated string"));
             }
-            let unescaped = self.unescape_string(py,&trimmed[1..trimmed.len() - 1])?;
+            let unescaped = self.unescape_string(py, &trimmed[1..trimmed.len() - 1])?;
             return Ok(PyString::new(py, &unescaped).into());
         }
 
@@ -1112,10 +1137,12 @@ impl<'a> Parser<'a> {
                     Some('r') => result.push('\r'),
                     Some('t') => result.push('\t'),
                     Some(other) => {
-                        return Err(self.err_here(py,format!("Invalid escape sequence: \\{}", other)));
+                        return Err(
+                            self.err_here(py, format!("Invalid escape sequence: \\{}", other))
+                        );
                     }
                     None => {
-                        return Err(self.err_here(py,"Unterminated escape sequence"));
+                        return Err(self.err_here(py, "Unterminated escape sequence"));
                     }
                 }
             } else {

--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -199,6 +199,44 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Build a `ToonDecodeError` with structured line context from `self.pos`.
+    fn err_here(&self, py: Python, msg: impl Into<String>) -> PyErr {
+        self.err_at(py, self.pos, msg)
+    }
+
+    /// Build a `ToonDecodeError` with structured line context from an
+    /// explicit line index.
+    ///
+    /// The returned exception carries:
+    /// - a default message of `"TOON parse error at line N: <msg>"`
+    ///   (or `"TOON parse error: <msg>"` if the line is unknown),
+    ///   accessible via `str(exc)` or `exc.args[0]`. The
+    ///   `"TOON parse error"` prefix is preserved from prior versions
+    ///   for backward compatibility with substring matchers.
+    /// - `.line` — the 1-based line number (`None` if the document is empty);
+    /// - `.source` — the raw source line including indentation
+    ///   (`None` if the document is empty).
+    fn err_at(&self, py: Python, line_idx: usize, msg: impl Into<String>) -> PyErr {
+        let (line_num, source) = if self.lines.is_empty() {
+            (None, None)
+        } else {
+            let clamped = line_idx.min(self.lines.len() - 1);
+            (Some(clamped + 1), Some(self.lines[clamped].to_string()))
+        };
+        let formatted = match line_num {
+            Some(n) => format!("TOON parse error at line {}: {}", n, msg.into()),
+            None => format!("TOON parse error: {}", msg.into()),
+        };
+        let err = PyErr::new::<crate::ToonDecodeError, _>(formatted);
+        // Materialize and decorate with structured attributes. The setattr
+        // calls cannot meaningfully fail (the exception object is a fresh
+        // BaseException instance), so we ignore Result.
+        let value = err.value(py);
+        let _ = value.setattr(pyo3::intern!(py, "line"), line_num);
+        let _ = value.setattr(pyo3::intern!(py, "source"), source);
+        err
+    }
+
     fn detect_indent_size(&mut self) {
         // Auto-detect indent size by finding first indented line
         for line in &self.lines {
@@ -214,7 +252,7 @@ impl<'a> Parser<'a> {
         self.indent_size = 2;
     }
 
-    fn validate_indentation(&self, line: &str) -> PyResult<()> {
+    fn validate_indentation(&self, py: Python, line: &str) -> PyResult<()> {
         if !self.strict {
             return Ok(());
         }
@@ -228,9 +266,7 @@ impl<'a> Parser<'a> {
         let indent_part = &line[..indent_len];
 
         if indent_part.contains('\t') {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                "TOON parse error: Tabs are not allowed in indentation",
-            ));
+            return Err(self.err_here(py,"Tabs are not allowed in indentation"));
         }
 
         // Use explicit_indent if provided, otherwise use auto-detected indent_size
@@ -241,8 +277,8 @@ impl<'a> Parser<'a> {
         };
 
         if check_indent > 0 && indent_len % check_indent != 0 {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                "TOON parse error: Indentation {} is not a multiple of indent size {}",
+            return Err(self.err_here(py,format!(
+                "Indentation {} is not a multiple of indent size {}",
                 indent_len, check_indent
             )));
         }
@@ -267,7 +303,7 @@ impl<'a> Parser<'a> {
         }
 
         let first_line = self.lines[self.pos];
-        self.validate_indentation(first_line)?;
+        self.validate_indentation(py,first_line)?;
         let first_line_trimmed = first_line.trim();
 
         // Check if it's a root array header - can be [N]: or [N]{fields}:
@@ -288,13 +324,14 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_root_array(&mut self, py: Python) -> PyResult<Py<PyAny>> {
+        let header_idx = self.pos;
         let header = self.lines[self.pos];
-        let (length, delimiter, fields) = self.parse_header(header)?;
+        let (length, delimiter, fields) = self.parse_header(py,header, header_idx)?;
         self.pos += 1;
 
         if let Some(field_names) = fields {
             // Tabular array
-            self.parse_tabular_array(py, length, delimiter, &field_names, 1)
+            self.parse_tabular_array(py, length, delimiter, &field_names, 1, header_idx)
         } else {
             // Check if inline or expanded
             let header_trimmed = header.trim();
@@ -302,16 +339,14 @@ impl<'a> Parser<'a> {
                 let after_colon = &header_trimmed[colon_pos + 2..].trim();
                 if !after_colon.is_empty() {
                     // Inline primitive array (values on same line)
-                    self.parse_inline_array(py, after_colon, delimiter, length)
+                    self.parse_inline_array(py, after_colon, delimiter, length, header_idx)
                 } else {
                     // Expanded list array (values on following lines)
-                    self.parse_expanded_array(py, length, 1)
+                    self.parse_expanded_array(py, length, 1, header_idx)
                 }
             } else {
                 // Malformed
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                    "TOON parse error: Invalid array header",
-                ))
+                Err(self.err_at(py,header_idx, "Invalid array header"))
             }
         }
     }
@@ -321,7 +356,7 @@ impl<'a> Parser<'a> {
 
         while self.pos < self.lines.len() {
             let line = self.lines[self.pos];
-            self.validate_indentation(line)?;
+            self.validate_indentation(py,line)?;
 
             let line_trimmed = line.trim();
             if line_trimmed.is_empty() {
@@ -406,12 +441,12 @@ impl<'a> Parser<'a> {
                             deep_merge_path(py, &dict, &segments, value, self.strict)?;
                         } else {
                             check_key_conflict(&dict, key_name, value.bind(py), self.strict)?;
-                            let key = self.parse_key(key_name)?;
+                            let key = self.parse_key(py,key_name)?;
                             dict.set_item(key, value)?;
                         }
                     } else {
                         let key = if was_quoted {
-                            self.parse_key(key_name)?
+                            self.parse_key(py,key_name)?
                         } else {
                             key_name.to_string()
                         };
@@ -423,7 +458,7 @@ impl<'a> Parser<'a> {
 
                 // Parse the key and check if it was quoted
                 let (should_expand, was_quoted) = self.should_expand_key(key_part);
-                let parsed_key = self.parse_key(key_part)?;
+                let parsed_key = self.parse_key(py,key_part)?;
                 self.pos += 1;
 
                 if value_part.is_empty() {
@@ -493,10 +528,7 @@ impl<'a> Parser<'a> {
                 }
             } else {
                 // Missing colon error
-                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "TOON parse error: Missing colon in line: {}",
-                    line_trimmed
-                )));
+                return Err(self.err_here(py,format!("Missing colon in line: {}", line_trimmed)));
             }
         }
 
@@ -509,51 +541,50 @@ impl<'a> Parser<'a> {
         header_line: &str,
         depth: usize,
     ) -> PyResult<Py<PyAny>> {
-        let (length, delimiter, fields) = self.parse_header(header_line)?;
+        let header_idx = self.pos;
+        let (length, delimiter, fields) = self.parse_header(py,header_line, header_idx)?;
         self.pos += 1;
 
         if let Some(field_names) = fields {
-            self.parse_tabular_array(py, length, delimiter, &field_names, depth + 1)
+            self.parse_tabular_array(py, length, delimiter, &field_names, depth + 1, header_idx)
         } else {
             let header_trimmed = header_line.trim();
             if let Some(bracket_end) = header_trimmed.find("]:") {
                 let after_colon = header_trimmed[bracket_end + 2..].trim();
                 if !after_colon.is_empty() {
-                    self.parse_inline_array(py, after_colon, delimiter, length)
+                    self.parse_inline_array(py, after_colon, delimiter, length, header_idx)
                 } else {
-                    self.parse_expanded_array(py, length, depth + 1)
+                    self.parse_expanded_array(py, length, depth + 1, header_idx)
                 }
             } else {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                    "TOON parse error: Invalid array header",
-                ))
+                Err(self.err_at(py,header_idx, "Invalid array header"))
             }
         }
     }
 
-    pub fn parse_header(&self, header: &str) -> PyResult<(usize, char, Option<Vec<String>>)> {
+    pub fn parse_header(
+        &self,
+        py: Python,
+        header: &str,
+        header_line_idx: usize,
+    ) -> PyResult<(usize, char, Option<Vec<String>>)> {
         let trimmed = header.trim();
 
         let bracket_start = self.find_array_bracket_start(trimmed).ok_or_else(|| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                "TOON parse error: Invalid array header: missing '['",
-            )
+            self.err_at(py,header_line_idx, "Invalid array header: missing '['")
         })?;
 
         let bracket_end = trimmed[bracket_start..]
             .find(']')
             .map(|pos| pos + bracket_start)
-            .ok_or_else(|| {
-                PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                    "TOON parse error: Invalid array header: missing ']'",
-                )
-            })?;
+            .ok_or_else(|| self.err_at(py,header_line_idx, "Invalid array header: missing ']'"))?;
 
         let bracket_content = &trimmed[bracket_start + 1..bracket_end];
 
         if bracket_content.trim_start().starts_with('#') {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                "TOON parse error: [#N] headers were removed in v2.0; use [N]",
+            return Err(self.err_at(py,
+                header_line_idx,
+                "[#N] headers were removed in v2.0; use [N]",
             ));
         }
 
@@ -568,10 +599,10 @@ impl<'a> Parser<'a> {
         };
 
         let length = length_str.parse::<usize>().map_err(|_| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                "TOON parse error: Invalid array length: {}",
-                length_str
-            ))
+            self.err_at(py,
+                header_line_idx,
+                format!("Invalid array length: {}", length_str),
+            )
         })?;
 
         let substring_after_bracket = &trimmed[bracket_end..];
@@ -579,21 +610,18 @@ impl<'a> Parser<'a> {
             .find_unquoted_char(substring_after_bracket, ':')
             .unwrap_or(substring_after_bracket.len());
         let fields = if let Some(brace_start) = substring_after_bracket[..colon_pos].find('{') {
-            let brace_end_relative =
-                substring_after_bracket[..colon_pos]
-                    .find('}')
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "TOON parse error: Invalid field list: missing '}'",
-                        )
-                    })?;
+            let brace_end_relative = substring_after_bracket[..colon_pos]
+                .find('}')
+                .ok_or_else(|| {
+                    self.err_at(py,header_line_idx, "Invalid field list: missing '}'")
+                })?;
 
             let field_content = &substring_after_bracket[brace_start + 1..brace_end_relative];
             let field_parts = self.split_by_delimiter(field_content, delimiter);
             let field_names: Vec<String> = field_parts
                 .iter()
                 .map(|f| {
-                    self.parse_key(f.trim())
+                    self.parse_key(py,f.trim())
                         .unwrap_or_else(|_| f.trim().to_string())
                 })
                 .collect();
@@ -612,6 +640,7 @@ impl<'a> Parser<'a> {
         delimiter: char,
         fields: &[String],
         expected_depth: usize,
+        header_line_idx: usize,
     ) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
 
@@ -620,7 +649,7 @@ impl<'a> Parser<'a> {
             let line_trimmed = line.trim();
 
             if !line_trimmed.is_empty() {
-                self.validate_indentation(line)?;
+                self.validate_indentation(py,line)?;
                 let line_depth = self.get_depth(line);
 
                 if line_depth < expected_depth {
@@ -645,9 +674,7 @@ impl<'a> Parser<'a> {
                 }
 
                 if self.strict {
-                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                        "TOON parse error: Blank line inside array",
-                    ));
+                    return Err(self.err_here(py,"Blank line inside array"));
                 }
                 self.pos += 1;
                 continue;
@@ -660,8 +687,8 @@ impl<'a> Parser<'a> {
             let values = self.split_by_delimiter(line_trimmed, delimiter);
 
             if values.len() != fields.len() {
-                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "TOON parse error: Tabular row has {} values but header defines {} fields",
+                return Err(self.err_here(py,format!(
+                    "Tabular row has {} values but header defines {} fields",
                     values.len(),
                     fields.len()
                 )));
@@ -682,10 +709,13 @@ impl<'a> Parser<'a> {
 
         let actual_len = list.len();
         if length > 0 && actual_len != length {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                "TOON parse error: Array declared length {} but found {} elements",
-                length, actual_len
-            )));
+            return Err(self.err_at(py,
+                header_line_idx,
+                format!(
+                    "Array declared length {} but found {} elements",
+                    length, actual_len
+                ),
+            ));
         }
 
         Ok(list.into())
@@ -697,15 +727,16 @@ impl<'a> Parser<'a> {
         values_str: &str,
         delimiter: char,
         length: usize,
+        header_line_idx: usize,
     ) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
 
         if values_str.is_empty() {
             if length > 0 {
-                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "TOON parse error: Array declared length {} but found 0 elements",
-                    length
-                )));
+                return Err(self.err_at(py,
+                    header_line_idx,
+                    format!("Array declared length {} but found 0 elements", length),
+                ));
             }
             return Ok(list.into());
         }
@@ -713,11 +744,14 @@ impl<'a> Parser<'a> {
         let values = self.split_by_delimiter(values_str, delimiter);
 
         if length > 0 && values.len() != length {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                "TOON parse error: Array declared length {} but found {} elements",
-                length,
-                values.len()
-            )));
+            return Err(self.err_at(py,
+                header_line_idx,
+                format!(
+                    "Array declared length {} but found {} elements",
+                    length,
+                    values.len()
+                ),
+            ));
         }
 
         for value_str in values {
@@ -733,6 +767,7 @@ impl<'a> Parser<'a> {
         py: Python,
         length: usize,
         expected_depth: usize,
+        header_line_idx: usize,
     ) -> PyResult<Py<PyAny>> {
         let list = PyList::empty(py);
 
@@ -741,7 +776,7 @@ impl<'a> Parser<'a> {
             let line_trimmed = line.trim();
 
             if !line_trimmed.is_empty() {
-                self.validate_indentation(line)?;
+                self.validate_indentation(py,line)?;
                 let line_depth = self.get_depth(line);
 
                 if line_depth < expected_depth {
@@ -766,9 +801,7 @@ impl<'a> Parser<'a> {
                 }
 
                 if self.strict {
-                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                        "TOON parse error: Blank line inside array",
-                    ));
+                    return Err(self.err_here(py,"Blank line inside array"));
                 }
                 self.pos += 1;
                 continue;
@@ -785,6 +818,7 @@ impl<'a> Parser<'a> {
             } else {
                 &line_trimmed[1..]
             };
+            let item_line_idx = self.pos;
             self.pos += 1;
 
             if item_str.is_empty() {
@@ -796,15 +830,23 @@ impl<'a> Parser<'a> {
             if item_str.starts_with('[') && item_str.contains("]:") {
                 let header_part = item_str.split("]:").next().unwrap();
                 let header_with_bracket = format!("{}]", header_part);
-                let (inner_len, inner_delim, _) = self.parse_header(&header_with_bracket)?;
+                let (inner_len, inner_delim, _) =
+                    self.parse_header(py,&header_with_bracket, item_line_idx)?;
 
                 let after_colon = item_str.split("]:").nth(1).unwrap_or("").trim();
 
                 if after_colon.is_empty() {
-                    let value = self.parse_expanded_array(py, inner_len, expected_depth + 1)?;
+                    let value =
+                        self.parse_expanded_array(py, inner_len, expected_depth + 1, item_line_idx)?;
                     list.append(value)?;
                 } else {
-                    let value = self.parse_inline_array(py, after_colon, inner_delim, inner_len)?;
+                    let value = self.parse_inline_array(
+                        py,
+                        after_colon,
+                        inner_delim,
+                        inner_len,
+                        item_line_idx,
+                    )?;
                     list.append(value)?;
                 }
             } else if item_str.contains(':') {
@@ -819,10 +861,13 @@ impl<'a> Parser<'a> {
 
         let actual_len = list.len();
         if length > 0 && actual_len != length {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                "TOON parse error: Array declared length {} but found {} elements",
-                length, actual_len
-            )));
+            return Err(self.err_at(py,
+                header_line_idx,
+                format!(
+                    "Array declared length {} but found {} elements",
+                    length, actual_len
+                ),
+            ));
         }
 
         Ok(list.into())
@@ -855,10 +900,10 @@ impl<'a> Parser<'a> {
                     } else {
                         key_part.split('[').next().unwrap()
                     };
-                    let key = self.parse_key(key_name)?;
+                    let key = self.parse_key(py,key_name)?;
                     dict.set_item(key, value)?;
                 } else {
-                    let key = self.parse_key(key_part)?;
+                    let key = self.parse_key(py,key_part)?;
                     self.pos += 1;
 
                     if value_part.is_empty() {
@@ -879,7 +924,7 @@ impl<'a> Parser<'a> {
 
         while self.pos < self.lines.len() {
             let line = self.lines[self.pos];
-            self.validate_indentation(line)?;
+            self.validate_indentation(py,line)?;
             let line_depth = self.get_depth(line);
 
             if line_depth <= list_depth {
@@ -913,12 +958,12 @@ impl<'a> Parser<'a> {
                     } else {
                         key_part.split('[').next().unwrap()
                     };
-                    let key = self.parse_key(key_name)?;
+                    let key = self.parse_key(py,key_name)?;
                     dict.set_item(key, value)?;
                     continue;
                 }
 
-                let key = self.parse_key(key_part)?;
+                let key = self.parse_key(py,key_part)?;
                 self.pos += 1;
 
                 if value_part.is_empty() {
@@ -941,11 +986,9 @@ impl<'a> Parser<'a> {
 
         if trimmed.starts_with('"') {
             if !trimmed.ends_with('"') || trimmed.len() < 2 {
-                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                    "TOON parse error: Unterminated string",
-                ));
+                return Err(self.err_here(py,"Unterminated string"));
             }
-            let unescaped = self.unescape_string(&trimmed[1..trimmed.len() - 1])?;
+            let unescaped = self.unescape_string(py,&trimmed[1..trimmed.len() - 1])?;
             return Ok(PyString::new(py, &unescaped).into());
         }
 
@@ -1046,17 +1089,17 @@ impl<'a> Parser<'a> {
         None
     }
 
-    fn parse_key(&self, s: &str) -> PyResult<String> {
+    fn parse_key(&self, py: Python, s: &str) -> PyResult<String> {
         let trimmed = s.trim();
 
         if trimmed.starts_with('"') && trimmed.ends_with('"') {
-            self.unescape_string(&trimmed[1..trimmed.len() - 1])
+            self.unescape_string(py, &trimmed[1..trimmed.len() - 1])
         } else {
             Ok(trimmed.to_string())
         }
     }
 
-    fn unescape_string(&self, s: &str) -> PyResult<String> {
+    fn unescape_string(&self, py: Python, s: &str) -> PyResult<String> {
         let mut result = String::new();
         let mut chars = s.chars();
 
@@ -1069,15 +1112,10 @@ impl<'a> Parser<'a> {
                     Some('r') => result.push('\r'),
                     Some('t') => result.push('\t'),
                     Some(other) => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                            "Invalid escape sequence: \\{}",
-                            other
-                        )));
+                        return Err(self.err_here(py,format!("Invalid escape sequence: \\{}", other)));
                     }
                     None => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "Unterminated escape sequence",
-                        ));
+                        return Err(self.err_here(py,"Unterminated escape sequence"));
                     }
                 }
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,6 @@
 mod deserialization;
 mod serialization;
 
-// `ToonDecodeError` — raised by the TOON decoder when input cannot be parsed.
-//
-// Subclasses `ValueError` and exposes two structured
-// attributes for programmatic consumers:
-//
-//   - `line: Optional[int]`   — 1-based line number where the error was
-//                                detected, if known.
-//   - `source: Optional[str]` — raw source line (including indentation)
-//                                where the error was detected, if known.
-//
-// The default message is formatted as `"Line N: <detail>"` when a line
-// number is available.
 pyo3::create_exception!(
     toons,
     ToonDecodeError,
@@ -62,15 +50,8 @@ mod toons {
     #[pymodule_export]
     const __version__: &str = env!("CARGO_PKG_VERSION");
 
-    /// Register the `ToonDecodeError` exception class on the module.
-    #[pymodule_init]
-    fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
-        m.add(
-            "ToonDecodeError",
-            m.py().get_type::<crate::ToonDecodeError>(),
-        )?;
-        Ok(())
-    }
+    #[pymodule_export]
+    use super::ToonDecodeError;
 
     /// Deserialize a TOON formatted string to a Python object.
     ///
@@ -86,10 +67,9 @@ mod toons {
     ///     A Python object (dict, list, or primitive) decoded from the TOON string
     ///
     /// Raises:
-    ///     ToonDecodeError: If the TOON string is malformed or contains invalid
-    ///         syntax. Subclasses ValueError, so `except ValueError` still
-    ///         catches. Carries structured `.line` (1-based) and `.source`
-    ///         (raw line) attributes for programmatic introspection.
+    ///     ToonDecodeError: If the input is malformed. Subclass of
+    ///         `ValueError`; carries `.line` (1-based) and `.source`
+    ///         (raw line) attributes for programmatic access.
     ///
     /// Example:
     ///     >>> import toons
@@ -123,8 +103,7 @@ mod toons {
     ///     A Python object (dict, list, or primitive) decoded from the file
     ///
     /// Raises:
-    ///     ToonDecodeError: If the TOON data is malformed or contains invalid
-    ///         syntax. Subclasses ValueError. See `loads` for details.
+    ///     ToonDecodeError: If the input is malformed. See `loads` for details.
     ///
     /// Example:
     ///     >>> import toons

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,25 @@
 mod deserialization;
 mod serialization;
 
+// `ToonDecodeError` — raised by the TOON decoder when input cannot be parsed.
+//
+// Subclasses `ValueError` and exposes two structured
+// attributes for programmatic consumers:
+//
+//   - `line: Optional[int]`   — 1-based line number where the error was
+//                                detected, if known.
+//   - `source: Optional[str]` — raw source line (including indentation)
+//                                where the error was detected, if known.
+//
+// The default message is formatted as `"Line N: <detail>"` when a line
+// number is available.
+pyo3::create_exception!(
+    toons,
+    ToonDecodeError,
+    pyo3::exceptions::PyValueError,
+    "Raised when the TOON decoder cannot parse the input. Subclass of ValueError. Carries `.line` (1-based int or None) and `.source` (raw line string or None) attributes."
+);
+
 /// Python bindings for TOON (Token-Oriented Object Notation)
 ///
 /// TOON is a compact, human-readable serialization format optimized for
@@ -43,6 +62,16 @@ mod toons {
     #[pymodule_export]
     const __version__: &str = env!("CARGO_PKG_VERSION");
 
+    /// Register the `ToonDecodeError` exception class on the module.
+    #[pymodule_init]
+    fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
+        m.add(
+            "ToonDecodeError",
+            m.py().get_type::<crate::ToonDecodeError>(),
+        )?;
+        Ok(())
+    }
+
     /// Deserialize a TOON formatted string to a Python object.
     ///
     /// Parse a string containing TOON (Token-Oriented Object Notation) data
@@ -57,7 +86,10 @@ mod toons {
     ///     A Python object (dict, list, or primitive) decoded from the TOON string
     ///
     /// Raises:
-    ///     ValueError: If the TOON string is malformed or contains invalid syntax
+    ///     ToonDecodeError: If the TOON string is malformed or contains invalid
+    ///         syntax. Subclasses ValueError, so `except ValueError` still
+    ///         catches. Carries structured `.line` (1-based) and `.source`
+    ///         (raw line) attributes for programmatic introspection.
     ///
     /// Example:
     ///     >>> import toons
@@ -91,7 +123,8 @@ mod toons {
     ///     A Python object (dict, list, or primitive) decoded from the file
     ///
     /// Raises:
-    ///     ValueError: If the TOON data is malformed or contains invalid syntax
+    ///     ToonDecodeError: If the TOON data is malformed or contains invalid
+    ///         syntax. Subclasses ValueError. See `loads` for details.
     ///
     /// Example:
     ///     >>> import toons

--- a/tests/integration/test_decode_errors.py
+++ b/tests/integration/test_decode_errors.py
@@ -1,0 +1,89 @@
+"""Integration tests for ToonDecodeError and its structured attributes."""
+
+import pytest
+
+import toons
+
+
+class TestToonDecodeErrorAttributes:
+    """Confirm ToonDecodeError carries `.line` and `.source` for every
+    parse-error path that has access to the line-oriented parser state."""
+
+    def test_count_mismatch_reports_header_line(self):
+        """Array length mismatch points at the header line, not the line after.
+
+        The header on line 5 declares 3 inline pipe-delimited values but the
+        following lines provide them in YAML-block form (a common LLM mistake).
+        The exception must point at the header.
+        """
+        content = (
+            "user_list:\n"
+            "  users[1|]:\n"
+            "    - name: Alice\n"
+            "      role: editor\n"
+            "      tags[3|]:\n"
+            '        "admin"\n'
+            '        "active"\n'
+            '        "premium"\n'
+        )
+        with pytest.raises(toons.ToonDecodeError) as excinfo:
+            toons.loads(content)
+        exc = excinfo.value
+        assert exc.line == 5
+        assert exc.source == "      tags[3|]:"
+        assert "TOON parse error at line 5" in str(exc)
+        assert "Array declared length 3 but found 0 elements" in str(exc)
+
+    def test_indentation_error_attaches_offending_line(self):
+        """Strict-mode indentation errors include the offending line verbatim."""
+        content = "a:\n  b:\n     c: 1\n"
+        with pytest.raises(toons.ToonDecodeError) as excinfo:
+            toons.loads(content)
+        exc = excinfo.value
+        assert exc.line == 3
+        assert exc.source == "     c: 1"
+        assert "Indentation 5 is not a multiple of indent size 2" in str(exc)
+
+    def test_missing_colon_attaches_offending_line(self):
+        """Object lines without a colon report the offending line."""
+        content = "a: 1\nb\nc: 3\n"
+        with pytest.raises(toons.ToonDecodeError) as excinfo:
+            toons.loads(content)
+        exc = excinfo.value
+        assert exc.line == 2
+        assert "b" in str(exc.source)
+
+
+class TestToonDecodeErrorClassHierarchy:
+    """ToonDecodeError MUST stay a subclass of ValueError for back-compat."""
+
+    def test_is_subclass_of_value_error(self):
+        assert issubclass(toons.ToonDecodeError, ValueError)
+
+    def test_caught_as_value_error(self):
+        """`except ValueError` still catches a ToonDecodeError."""
+        with pytest.raises(ValueError):
+            toons.loads("a:\n  b:\n     c: 1\n")
+
+    def test_attributes_always_present(self):
+        """`.line` and `.source` must exist on every raised instance,
+        even if both are None."""
+        try:
+            toons.loads("a:\n  b:\n     c: 1\n")
+        except toons.ToonDecodeError as exc:
+            assert hasattr(exc, "line")
+            assert hasattr(exc, "source")
+
+
+class TestPathExpansionErrorClass:
+    """Path expansion conflicts must also raise ToonDecodeError, not a
+    bare ValueError — they are parse-time decode errors."""
+
+    def test_path_expansion_conflict_raises_toon_decode_error(self):
+        """Same key reached via plain and via path expansion conflicts when
+        strict expand_paths='safe' detects the type mismatch."""
+        # `parent: scalar` then a dotted key `parent.child: 1` would try to
+        # turn `parent` into a dict — a type conflict in strict mode.
+        content = "parent: scalar\nparent.child: 1\n"
+        with pytest.raises(toons.ToonDecodeError):
+            toons.loads(content, expand_paths="safe")

--- a/toons.pyi
+++ b/toons.pyi
@@ -2,6 +2,32 @@
 
 from typing import IO, Any, Optional
 
+class ToonDecodeError(ValueError):
+    """Exception raised by the TOON decoder when input cannot be parsed.
+
+    Subclasses ``ValueError`` for backward compatibility, so existing
+    ``except ValueError`` handlers continue to catch parse failures.
+
+    Attributes:
+        line: 1-based line number where the error was detected, or ``None``
+            if the location is unknown (e.g. empty input).
+        source: The raw source line (including original indentation) where
+            the error was detected, or ``None`` if unknown.
+
+    The default message is formatted as ``"Line N: <detail>"`` when a line
+    number is available, matching the canonical TypeScript reference
+    implementation (``@toon-format/toon``).
+
+    Example:
+        >>> try:
+        ...     toons.loads("items[3]: a,b")
+        ... except toons.ToonDecodeError as exc:
+        ...     print(exc.line, exc.source, str(exc))
+    """
+
+    line: Optional[int]
+    source: Optional[str]
+
 def load(
     fp: IO[str],
     *,
@@ -19,6 +45,9 @@ def load(
 
     Returns:
         The parsed Python object.
+
+    Raises:
+        ToonDecodeError: If the input is malformed. Subclass of ValueError.
     """
     ...
 
@@ -39,6 +68,10 @@ def loads(
 
     Returns:
         The parsed Python object.
+
+    Raises:
+        ToonDecodeError: If the input is malformed. Subclass of ValueError;
+            carries structured ``.line`` and ``.source`` attributes.
     """
     ...
 


### PR DESCRIPTION
Brings decoder error reporting to parity with the canonical TypeScript reference (`@toon-format/toon`).

The decoder now raises `ToonDecodeError` - a subclass of `ValueError` exported as `toons.ToonDecodeError` - with two structured attributes:

- `line: Optional[int]` - 1-based line of the source line
- `source: Optional[str]` -  raw line, indentation preserved

Default message becomes `"TOON parse error at line N: <detail>"` when a line is known, `"TOON parse error: <detail>"` otherwise. The `"TOON parse error"` substring is preserved for backward compatibility with substring matchers.

Also fixes a latent off-by-one: array-length-mismatch errors in `parse_inline_array` / `parse_tabular_array` / `parse_expanded_array` were reporting the line *after* the header. Achieved by threading an explicit `header_line_idx` parameter through these functions.

### Example

```python
import toons

content = """user_list:
  users[1|]:
    - name: Alice
      role: editor
      tags[3|]:
        "admin"
        "active"
        "premium"
"""

try:
    toons.loads(content)
except toons.ToonDecodeError as exc:
    print(exc)         # TOON parse error at line 5: Array declared length 3 but found 0 elements
    print(exc.line)    # 5
    print(exc.source)  # '      tags[3|]:'
```

### Backward compatibility

- `ToonDecodeError` IS-A `ValueError`, so `except ValueError` keeps catching.
- The `"TOON parse error"` substring is preserved in every message
- The two existing `pytest.raises(ValueError, match="Blank line inside array")` tests pass unchanged.
- Only `type(exc) is ValueError` exact-type comparisons are affected.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue) — off-by-one in array-length-mismatch line reporting
- [x] New feature (non-breaking change which adds functionality) — `ToonDecodeError` class with `.line` and `.source` attributes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update — `lib.rs` docstrings, `toons.pyi`

## Related Issues

Fixes #11 

## Checklist

- [x] Tests pass locally
- [x] New tests added for new functionality
- [x] Code follows project style guidelines
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated
- [x] Conventional commit format used
- [x] Pre-commit ran on all modified files