### PR TITLE
fix(deserialization): parse quoted strings with colons as primitives in expanded arrays

### DIFF
--- a/src/deserialization.rs
+++ b/src/deserialization.rs
@@ -807,7 +807,7 @@ impl<'a> Parser<'a> {
                     let value = self.parse_inline_array(py, after_colon, inner_delim, inner_len)?;
                     list.append(value)?;
                 }
-            } else if item_str.contains(':') {
+            } else if self.find_key_value_colon(item_str).is_some() {
                 self.pos -= 1;
                 let value = self.parse_list_item_object(py, expected_depth)?;
                 list.append(value)?;

--- a/tests/integration/test_complex_regression.py
+++ b/tests/integration/test_complex_regression.py
@@ -85,3 +85,24 @@ class TestComplexRegression:
 
         # Verify both methods produce the same data
         assert loaded_data == toon_data
+
+
+class TestPrimitiveArrayColonRegression:
+    """Regression tests for §9.4 expanded primitive arrays containing colons (GitHub issue)."""
+
+    def test_quoted_strings_with_colon_in_expanded_array(self):
+        """Quoted strings containing a colon must be parsed as primitives, not objects (§9.3)."""
+        result = toons.loads('items[2|]:\n  - "a:b"\n  - "c:d"\n')
+        assert result == {"items": ["a:b", "c:d"]}
+
+    def test_single_quoted_string_with_colon_in_expanded_array(self):
+        """Single quoted string with colon in expanded primitive array."""
+        result = toons.loads('tags[1|]:\n  - "http://example.com"\n')
+        assert result == {"tags": ["http://example.com"]}
+
+    def test_mixed_primitives_and_colon_strings_in_expanded_array(self):
+        """Expanded array mixing plain strings and quoted strings with colons."""
+        result = toons.loads(
+            'values[3|]:\n  - plain\n  - "key:value"\n  - another\n'
+        )
+        assert result == {"values": ["plain", "key:value", "another"]}


### PR DESCRIPTION
In parse_expanded_array, item_str.contains(':') was used to detect object items, which incorrectly matched quoted strings like "a:b". Replace with find_key_value_colon() which skips colons inside quotes, matching the disambiguation rule in spec §9.3.

## Related Issues
Fixes #13
